### PR TITLE
Guess flycut preference path for newer versions of MacOS

### DIFF
--- a/cliphist-flycut.el
+++ b/cliphist-flycut.el
@@ -55,6 +55,8 @@ It's decided by Flycut version."
   (let* ((rlt (file-truename "~/Library/Preferences/com.generalarcade.flycut.plist")))
     (unless (file-exists-p rlt)
       (setq rlt (file-truename "~/Library/Application Support/Flycut/com.generalarcade.flycut.plist")))
+    (unless (file-exists-p rlt)
+      (setq rlt (file-truename "~/Library/Containers/com.generalarcade.flycut/Data/Library/Preferences/com.generalarcade.flycut.plist")))
     rlt))
 
 (defun cliphist-flycut-is-bplist ()


### PR DESCRIPTION
MacOS 10.13 and onwards can fail guessing the flycut preference path